### PR TITLE
Handle cases where `stale_checks` callback returns `nil`

### DIFF
--- a/lib/phoenix_etag.ex
+++ b/lib/phoenix_etag.ex
@@ -192,10 +192,10 @@ defmodule PhoenixETag do
       |> put_etag(etag)
       |> put_last_modified(modified)
 
-    if stale?(conn, etag, modified) do
-      fun.(conn, Map.take(conn.assigns, [:layout]))
-    else
+    if fresh?(conn, etag, modified) do
       Plug.Conn.send_resp(conn, 304, "")
+    else
+      fun.(conn, Map.take(conn.assigns, [:layout]))
     end
   end
 
@@ -212,36 +212,34 @@ defmodule PhoenixETag do
     Plug.Conn.put_resp_header(conn, "last-modified", format_date(modified))
   end
 
-  defp stale?(conn, etag, modified) do
+  defp fresh?(conn, etag, modified) do
     modified_since = List.first(Plug.Conn.get_req_header(conn, "if-modified-since"))
     none_match = List.first(Plug.Conn.get_req_header(conn, "if-none-match"))
 
-    if get_or_head?(conn) and (modified_since || none_match) do
-      modified_since?(modified_since, modified) or none_match?(none_match, etag)
-    else
-      true
-    end
+    !get_or_head?(conn) ||
+      modified_since_fresh?(modified_since, modified) ||
+      none_match_fresh?(none_match, etag)
   end
 
   defp get_or_head?(%{method: method}), do: method in ["GET", "HEAD"]
 
-  defp modified_since?(header, last_modified) do
-    if header && last_modified do
-      modified_since = parse_date(header)
-      last_modified = to_unix(last_modified)
-      last_modified > modified_since
-    else
-      false
-    end
+  defp modified_since_fresh?(header, last_modified)
+  defp modified_since_fresh?(nil, _), do: false
+  defp modified_since_fresh?(_, nil), do: false
+
+  defp modified_since_fresh?(header, last_modified) do
+    modified_since = parse_date(header)
+    last_modified = to_unix(last_modified)
+    last_modified <= modified_since
   end
 
-  defp none_match?(none_match, etag) do
-    if none_match && etag do
-      none_match = Plug.Conn.Utils.list(none_match)
-      etag not in none_match and "*" not in none_match
-    else
-      false
-    end
+  defp none_match_fresh?(none_match, etag)
+  defp none_match_fresh?(_, nil), do: false
+  defp none_match_fresh?(nil, _), do: false
+
+  defp none_match_fresh?(none_match, etag) do
+    none_match = Plug.Conn.Utils.list(none_match)
+    etag in none_match or "*" in none_match
   end
 
   defp to_unix(%DateTime{} = dt), do: DateTime.to_unix(dt)

--- a/lib/phoenix_etag.ex
+++ b/lib/phoenix_etag.ex
@@ -217,8 +217,8 @@ defmodule PhoenixETag do
     none_match = List.first(Plug.Conn.get_req_header(conn, "if-none-match"))
 
     !get_or_head?(conn) ||
-      modified_since_fresh?(modified_since, modified) ||
-      none_match_fresh?(none_match, etag)
+      none_match_fresh?(none_match, etag) ||
+      modified_since_fresh?(modified_since, modified)
   end
 
   defp get_or_head?(%{method: method}), do: method in ["GET", "HEAD"]

--- a/test/phoenix_etag_test.exs
+++ b/test/phoenix_etag_test.exs
@@ -13,18 +13,28 @@ defmodule PhoenixETagTest do
       [etag: PhoenixETag.schema_etag(data), last_modified: PhoenixETag.schema_last_modified(data)]
     end
 
+    def stale_checks("show." <> _format, %{checks: checks}), do: checks
+
     def render("show.json", %{data: data}) do
       %{id: data.id}
     end
 
-    def render("show.html", %{data: data}) do
-      "Template for id: #{data.id}"
+    def render("show.html", %{data: %{id: id}}) do
+      "Template for id: #{id}"
+    end
+
+    def render("show.html", %{data: d}) do
+      "Template for: #{inspect(d)}"
     end
 
     def render("inner.html", %{conn: conn}) do
       mod = Phoenix.Controller.view_module(conn)
       tmpl = Phoenix.Controller.view_template(conn)
       "View module is #{mod} and view template is #{tmpl}."
+    end
+
+    def render("show." <> _format, %{checks: checks}) do
+      "Template for checks: #{inspect(checks)}"
     end
   end
 
@@ -89,41 +99,76 @@ defmodule PhoenixETagTest do
 
   describe "render_if_stale" do
     test "responds with etag" do
-      conn = render_if_stale(conn(), "show.html", data: schema())
+      conn = render_if_stale(conn(), "show.html", checks: [etag: @etag])
       assert get_resp_header(conn, "etag") == [@etag]
+      assert get_resp_header(conn, "last-modified") == []
       assert conn.status == 200
     end
 
     test "responds with last-modified" do
-      conn = render_if_stale(conn(), "show.html", data: schema())
+      conn = render_if_stale(conn(), "show.html", checks: [last_modified: @date])
       assert get_resp_header(conn, "last-modified") == [@last_modified]
+      assert get_resp_header(conn, "etag") == []
       assert conn.status == 200
     end
 
-    test "respnds with 304 for fresh content based on etag" do
-      conn = put_req_header(conn(), "if-none-match", @etag)
-      conn = render_if_stale(conn, "show.html", data: schema())
-      assert conn.status == 304
-      assert conn.state == :sent
+    test "responds with both" do
+      conn = render_if_stale(conn(), "show.html", checks: [last_modified: @date, etag: @etag])
+      assert get_resp_header(conn, "last-modified") == [@last_modified]
+      assert get_resp_header(conn, "etag") == [@etag]
+      assert conn.status == 200
+    end
+
+    test "responds with neither" do
+      testcases = [
+        [],
+        [last_modified: nil, etag: nil]
+      ]
+
+      for checks <- testcases do
+        conn = render_if_stale(conn(), "show.html", checks: checks)
+        assert get_resp_header(conn, "last-modified") == []
+        assert get_resp_header(conn, "etag") == []
+        assert conn.status == 200
+      end
+    end
+
+    test "responds with 304 for fresh content based on etag" do
+      testcases = [
+        [],
+        200,
+        {[etag: nil], 200},
+        {[etag: "W/ etag2"], 200},
+        {[etag: "W/ etag2", last_modified: @date], 200},
+        {[etag: nil, last_modified: @date], 200},
+        {[etag: "W/ etag1"], 304},
+        {[etag: "W/ etag1", last_modified: nil], 304},
+        {[etag: "W/ etag1", last_modified: @date], 304}
+      ]
+
+      for {checks, expected_status} <- testcases do
+        conn = put_req_header(conn(), "if-none-match", "W/ etag1")
+        conn = render_if_stale(conn, "show.html", checks: checks)
+        assert conn.status == expected_status
+        assert conn.state == :sent
+      end
     end
 
     test "responds with 304 for fresh content based on last_modified" do
-      conn = put_req_header(conn(), "if-modified-since", @last_modified)
-      conn = render_if_stale(conn, "show.html", data: schema())
-      assert conn.status == 304
-      assert conn.state == :sent
-    end
+      testcases = [
+        {@date, 304},
+        {@naive, 304},
+        {DateTime.add(@date, -1, :second), 304},
+        {DateTime.add(@date, 1, :second), 200},
+        {nil, 200}
+      ]
 
-    test "skips if etag does not match" do
-      conn = put_req_header(conn(), "if-none-match", "bad value")
-      conn = render_if_stale(conn, "show.html", data: schema())
-      assert conn.status == 200
-    end
-
-    test "skips if last_modified does not match" do
-      conn = put_req_header(conn(), "if-modified-since", "Thu, 16 Feb 2016 16:28:05 GMT")
-      conn = render_if_stale(conn, "show.html", data: schema())
-      assert conn.status == 200
+      for {date, expected_status} <- testcases do
+        conn = put_req_header(conn(), "if-modified-since", @last_modified)
+        conn = render_if_stale(conn, "show.html", checks: [last_modified: date])
+        assert conn.status == expected_status
+        assert conn.state == :sent
+      end
     end
   end
 


### PR DESCRIPTION
Previously, returning `nil` for the `etag` or `last_modified` value in the `stale_check` callback would lead to a 304 NOT MODIFIED if a user requested the resource while providing a `if-none-match` or `if-modified-since` header in their request. I wasn't the only one to notice this. [This PR](https://github.com/michalmuskala/phoenix_etag/pull/4) has been open since 2017, but it wasn't a complete fix and doesn't include tests.

I have added a significant number of test cases as well as refactored the implementation to be more logical to my brain. It was easier for me to think about the narrower cases where the data was _fresh_ (they provided the relevant header and the `stale_check` provided a matching value), rather than the cases where it should be considered _stale_ (everything else).

We're definitely not fully compliant with [RFC9110](https://www.rfc-editor.org/rfc/rfc9110#name-precedence-of-preconditions), but it's an improvement.